### PR TITLE
fake webhook - for bump usage

### DIFF
--- a/app/controllers/bump_controller.rb
+++ b/app/controllers/bump_controller.rb
@@ -1,0 +1,14 @@
+class BumpController < ApplicationController
+  def fake_webhook
+    # POST
+    # this is a webhook, to be called implemented in bump.sh
+    5.times { puts 'X' * 10 + __method__.to_s + 'X' * 10 }
+    p params
+
+    redirect_to ping_webhook_path, notice: 'POST request done on /fake_webhook'
+  end
+
+  def ping
+    # GET
+  end
+end

--- a/app/views/bump/ping.html.erb
+++ b/app/views/bump/ping.html.erb
@@ -1,0 +1,1 @@
+<h1>Ping this webhook route from <%= link_to "Bump", 'https://bump.sh' %></h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,7 @@ Rails.application.routes.draw do
   get "tanks/details", to: "tanks#details"
   resources :tanks
   root to: 'pages#home'
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  post :fake_webhook, to: 'bump#fake_webhook'
+  get :ping_webhook, to: 'bump#ping'
 end


### PR DESCRIPTION
Beside following our petrol consumption, I'm also working at bump.sh,;
where I'm currently implementing webhook support.

This commit add a fake route POST /fake_webhook, to be called from Bump app.