### PR TITLE
Remove redirection to ensure webhook works well

### DIFF
--- a/app/controllers/bump_controller.rb
+++ b/app/controllers/bump_controller.rb
@@ -7,7 +7,7 @@ class BumpController < ApplicationController
     5.times { puts 'X' * 10 + __method__.to_s + 'X' * 10 }
     p params
 
-    redirect_to ping_webhook_path, notice: 'POST request done on /fake_webhook'
+    # redirect_to ping_webhook_path, notice: 'POST request done on /fake_webhook'
   end
 
   def ping


### PR DESCRIPTION
Redirection 302 are not allowed after POST request, cf https://github.com/bump-sh/bump/pull/1963#discussion_r849420086